### PR TITLE
Various dep bumps and minor fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ custom_debug = "0.5"
 anyhow = "1.0"
 futures = "0.3"
 tokio = { version = "1", features = ["net"] }
-tokio-util = { version = "0.6", features = ["codec"] }
+tokio-util = { version = "0.7", features = ["codec"] }
 nom = "4"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 bytes = "1"
 custom_debug = "0.5"
-failure = "0.1.8"
+anyhow = "1.0"
 futures = "0.3"
 tokio = { version = "1", features = ["net"] }
 tokio-util = { version = "0.6", features = ["codec"] }

--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -13,7 +13,7 @@ use tokio_stomp_2::*;
 // `docker run -p 61613:61613 rmohr/activemq:latest`
 
 #[tokio::main]
-async fn main() -> Result<(), failure::Error> {
+async fn main() -> Result<(), anyhow::Error> {
     let conn = client::connect("127.0.0.1:61613", None, None).await?;
 
     tokio::time::sleep(Duration::from_millis(200)).await;

--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), failure::Error> {
             ToServer::Send {
                 destination: "rusty".into(),
                 transaction: None,
-                headers: vec!(),
+                headers: vec![],
                 body: Some(b"Hello there rustaceans!".to_vec()),
             }
             .into(),

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -19,7 +19,7 @@ async fn client(listens: &str, sends: &str, msg: &[u8]) -> Result<(), failure::E
             ToServer::Send {
                 destination: sends.into(),
                 transaction: None,
-                headers: vec!(),
+                headers: vec![],
                 body: Some(msg.to_vec()),
             }
             .into(),

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -10,7 +10,7 @@ use tokio_stomp_2::*;
 // You can start a simple STOMP server with docker:
 // `docker run -p 61613:61613 rmohr/activemq:latest`
 
-async fn client(listens: &str, sends: &str, msg: &[u8]) -> Result<(), failure::Error> {
+async fn client(listens: &str, sends: &str, msg: &[u8]) -> Result<(), anyhow::Error> {
     let mut conn = client::connect("127.0.0.1:61613", None, None).await?;
     conn.send(client::subscribe(listens, "myid")).await?;
 
@@ -29,14 +29,14 @@ async fn client(listens: &str, sends: &str, msg: &[u8]) -> Result<(), failure::E
         if let Some(FromServer::Message { body, .. }) = msg.as_ref().map(|m| &m.content) {
             println!("{}", String::from_utf8_lossy(&body.as_ref().unwrap()));
         } else {
-            failure::bail!("Unexpected: {:?}", msg)
+            anyhow::bail!("Unexpected: {:?}", msg)
         }
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
 }
 
 #[tokio::main]
-async fn main() -> Result<(), failure::Error> {
+async fn main() -> Result<(), anyhow::Error> {
     let fut1 = Box::pin(client("ping", "pong", b"PONG!"));
     let fut2 = Box::pin(client("pong", "ping", b"PING!"));
 

--- a/examples/receive_message.rs
+++ b/examples/receive_message.rs
@@ -8,15 +8,22 @@ use tokio_stomp_2::FromServer;
 
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
-  let mut conn = client::connect("127.0.0.1:61613", None, None).await.unwrap();
+    let mut conn = client::connect("127.0.0.1:61613", None, None)
+        .await
+        .unwrap();
 
-  conn.send(client::subscribe("queue.test", "custom-subscriber-id")).await.unwrap();
+    conn.send(client::subscribe("queue.test", "custom-subscriber-id"))
+        .await
+        .unwrap();
 
-  while let Some(item) = conn.next().await {
-    if let FromServer::Message { message_id,body, .. } = item.unwrap().content {
-      println!("{:?}", body);
-      println!("{}", message_id);
+    while let Some(item) = conn.next().await {
+        if let FromServer::Message {
+            message_id, body, ..
+        } = item.unwrap().content
+        {
+            println!("{:?}", body);
+            println!("{}", message_id);
+        }
     }
-  }
-  Ok(())
+    Ok(())
 }

--- a/examples/send_message.rs
+++ b/examples/send_message.rs
@@ -8,17 +8,20 @@ use tokio_stomp_2::ToServer;
 
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
-  let mut conn = client::connect("127.0.0.1:61613", None, None).await.unwrap();
+    let mut conn = client::connect("127.0.0.1:61613", None, None)
+        .await
+        .unwrap();
 
-  conn.send(
-    ToServer::Send {
-        destination: "queue.test".into(),
-        transaction: None,
-        headers: vec!(),
-        body: Some(b"Hello there rustaceans!".to_vec()),
-    }
-    .into(),
-  )
-  .await.expect("sending message to server");
-  Ok(())
+    conn.send(
+        ToServer::Send {
+            destination: "queue.test".into(),
+            transaction: None,
+            headers: vec![],
+            body: Some(b"Hello there rustaceans!".to_vec()),
+        }
+        .into(),
+    )
+    .await
+    .expect("sending message to server");
+    Ok(())
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,7 @@ use futures::sink::SinkExt;
 use tokio::net::TcpStream;
 use tokio_util::codec::{Decoder, Encoder, Framed};
 
-type ClientTransport = Framed<TcpStream, ClientCodec>;
+pub type ClientTransport = Framed<TcpStream, ClientCodec>;
 
 use crate::frame;
 
@@ -20,9 +20,7 @@ pub async fn connect(
     address: &str,
     login: Option<String>,
     passcode: Option<String>,
-) -> Result<
-    impl Stream<Item = Result<Message<FromServer>>> + Sink<Message<ToServer>, Error = anyhow::Error>,
-> {
+) -> Result<ClientTransport> {
     let addr = address.to_socket_addrs().unwrap().next().unwrap();
     let tcp = TcpStream::connect(&addr).await?;
     let mut transport = ClientCodec.framed(tcp);
@@ -71,7 +69,7 @@ pub fn subscribe(dest: &str, id: &str) -> Message<ToServer> {
     .into()
 }
 
-struct ClientCodec;
+pub struct ClientCodec;
 
 impl Decoder for ClientCodec {
     type Item = Message<FromServer>;

--- a/src/client.rs
+++ b/src/client.rs
@@ -25,7 +25,7 @@ pub async fn connect(
     let tcp = TcpStream::connect(&addr).await?;
     let mut transport = ClientCodec.framed(tcp);
     client_handshake(&mut transport, address.to_string(), login, passcode).await?;
-    return Ok(transport);
+    Ok(transport)
 }
 
 async fn client_handshake(
@@ -37,9 +37,9 @@ async fn client_handshake(
     let connect = Message {
         content: ToServer::Connect {
             accept_version: String::from("1.2"),
-            host: host,
-            login: login,
-            passcode: passcode,
+            host,
+            login,
+            passcode,
             heartbeat: None,
         },
         extra_headers: vec![],
@@ -76,7 +76,7 @@ impl Decoder for ClientCodec {
     type Error = anyhow::Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>> {
-        let (item, offset) = match frame::parse_frame(&src) {
+        let (item, offset) = match frame::parse_frame(src) {
             Ok((remain, frame)) => (
                 Message::<FromServer>::from_frame(frame),
                 remain.as_ptr() as usize - src.as_ptr() as usize,

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -25,11 +25,11 @@ impl<'a> Frame<'a> {
             // filter out headers with None value
             .filter_map(|&(k, ref v)| v.as_ref().map(|i| (k, (&*i).clone())))
             .collect();
-        return Frame {
+        Frame {
             command,
             headers,
             body,
-        };
+        }
     }
 
     pub(crate) fn serialize(&self, buffer: &mut BytesMut) {
@@ -161,7 +161,7 @@ fn all_headers<'a>(headers: &'a [(&'a [u8], Cow<'a, [u8]>)]) -> Vec<(String, Str
         );
         res.push(entry);
     }
-    return res;
+    res
 }
 
 fn expect_header<'a>(headers: &'a [(&'a [u8], Cow<'a, [u8]>)], key: &'a str) -> Result<String> {
@@ -348,7 +348,7 @@ fn get_content_length_header(body: &[u8]) -> Vec<u8> {
 }
 
 fn parse_heartbeat(hb: &str) -> Result<(u32, u32)> {
-    let mut split = hb.splitn(1, ',');
+    let mut split = hb.splitn(2, ',');
     let left = split.next().ok_or_else(|| anyhow!("Bad heartbeat"))?;
     let right = split.next().ok_or_else(|| anyhow!("Bad heartbeat"))?;
     Ok((left.parse()?, right.parse()?))
@@ -382,7 +382,7 @@ impl ToServer {
             ),
 
             Disconnect { ref receipt } => {
-                Frame::new(b"DISCONNECT", &[(b"receipt", sb(&receipt))], None)
+                Frame::new(b"DISCONNECT", &[(b"receipt", sb(receipt))], None)
             }
 
             Subscribe {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,5 +1,5 @@
+use anyhow::{anyhow, bail};
 use bytes::{BufMut, BytesMut};
-use failure::{bail, format_err};
 
 use std::borrow::Cow;
 
@@ -15,36 +15,40 @@ pub(crate) struct Frame<'a> {
 }
 
 impl<'a> Frame<'a> {
-
-    pub(crate) fn new(command: &'a [u8], headers: &[(&'a [u8], Option<Cow<'a, [u8]>>)],
-        body: Option<&'a [u8]> ) -> Frame<'a> {
-        let headers = headers.iter()
+    pub(crate) fn new(
+        command: &'a [u8],
+        headers: &[(&'a [u8], Option<Cow<'a, [u8]>>)],
+        body: Option<&'a [u8]>,
+    ) -> Frame<'a> {
+        let headers = headers
+            .iter()
             // filter out headers with None value
             .filter_map(|&(k, ref v)| v.as_ref().map(|i| (k, (&*i).clone())))
             .collect();
-        return Frame { command, headers, body };
+        return Frame {
+            command,
+            headers,
+            body,
+        };
     }
 
     pub(crate) fn serialize(&self, buffer: &mut BytesMut) {
-        
         fn write_escaped(b: u8, buffer: &mut BytesMut) {
-
             match b {
-                b'\r' => 
-                    buffer.put_slice(b"\\r"),
-                b'\n' => 
-                    buffer.put_slice(b"\\n"),
-                b':' => 
-                    buffer.put_slice(b"\\c"),
-                b'\\' => 
-                    buffer.put_slice(b"\\\\"),
+                b'\r' => buffer.put_slice(b"\\r"),
+                b'\n' => buffer.put_slice(b"\\n"),
+                b':' => buffer.put_slice(b"\\c"),
+                b'\\' => buffer.put_slice(b"\\\\"),
                 b => buffer.put_u8(b),
             }
         }
 
         let requires = self.command.len()
             + self.body.map(|b| b.len() + 20).unwrap_or(0)
-            + self.headers.iter().fold(0, |acc, &(ref k, ref v)| acc + k.len() + v.len())
+            + self
+                .headers
+                .iter()
+                .fold(0, |acc, &(ref k, ref v)| acc + k.len() + v.len())
             + 30;
         if buffer.remaining_mut() < requires {
             buffer.reserve(requires);
@@ -151,14 +155,17 @@ fn fetch_header<'a>(headers: &'a [(&'a [u8], Cow<'a, [u8]>)], key: &'a str) -> O
 fn all_headers<'a>(headers: &'a [(&'a [u8], Cow<'a, [u8]>)]) -> Vec<(String, String)> {
     let mut res = Vec::new();
     for &(k, ref v) in headers {
-        let entry = (String::from_utf8(k.to_vec()).unwrap(), String::from_utf8(v.to_vec()).unwrap());
+        let entry = (
+            String::from_utf8(k.to_vec()).unwrap(),
+            String::from_utf8(v.to_vec()).unwrap(),
+        );
         res.push(entry);
     }
     return res;
 }
 
 fn expect_header<'a>(headers: &'a [(&'a [u8], Cow<'a, [u8]>)], key: &'a str) -> Result<String> {
-    fetch_header(headers, key).ok_or_else(|| format_err!("Expected header '{}' missing", key))
+    fetch_header(headers, key).ok_or_else(|| anyhow!("Expected header '{}' missing", key))
 }
 
 impl<'a> Frame<'a> {
@@ -342,8 +349,8 @@ fn get_content_length_header(body: &[u8]) -> Vec<u8> {
 
 fn parse_heartbeat(hb: &str) -> Result<(u32, u32)> {
     let mut split = hb.splitn(1, ',');
-    let left = split.next().ok_or_else(|| format_err!("Bad heartbeat"))?;
-    let right = split.next().ok_or_else(|| format_err!("Bad heartbeat"))?;
+    let left = split.next().ok_or_else(|| anyhow!("Bad heartbeat"))?;
+    let right = split.next().ok_or_else(|| anyhow!("Bad heartbeat"))?;
     Ok((left.parse()?, right.parse()?))
 }
 
@@ -353,7 +360,12 @@ impl ToServer {
         use Cow::*;
         use ToServer::*;
         match *self {
-            Connect { ref accept_version, ref host, ref login, ref passcode, ref heartbeat,
+            Connect {
+                ref accept_version,
+                ref host,
+                ref login,
+                ref passcode,
+                ref heartbeat,
             } => Frame::new(
                 b"CONNECT",
                 &[
@@ -361,56 +373,78 @@ impl ToServer {
                     (b"host", Some(Borrowed(host.as_bytes()))),
                     (b"login", sb(login)),
                     (b"passcode", sb(passcode)),
-                    (b"heart-beat", 
+                    (
+                        b"heart-beat",
                         heartbeat.map(|(v1, v2)| Owned(format!("{},{}", v1, v2).into())),
                     ),
                 ],
                 None,
             ),
 
-            Disconnect { ref receipt } => 
-                Frame::new(b"DISCONNECT", &[(b"receipt", sb(&receipt))], None),
+            Disconnect { ref receipt } => {
+                Frame::new(b"DISCONNECT", &[(b"receipt", sb(&receipt))], None)
+            }
 
-            Subscribe { ref destination, ref id, ref ack, } => 
-                Frame::new(
+            Subscribe {
+                ref destination,
+                ref id,
+                ref ack,
+            } => Frame::new(
                 b"SUBSCRIBE",
                 &[
                     (b"destination", Some(Borrowed(destination.as_bytes()))),
                     (b"id", Some(Borrowed(id.as_bytes()))),
-                    (b"ack", ack.map(|ack| match ack {
+                    (
+                        b"ack",
+                        ack.map(|ack| match ack {
                             AckMode::Auto => Borrowed(&b"auto"[..]),
                             AckMode::Client => Borrowed(&b"client"[..]),
                             AckMode::ClientIndividual => Borrowed(&b"client-individual"[..]),
-                        }))],
+                        }),
+                    ),
+                ],
                 None,
             ),
 
-            Unsubscribe { ref id } => 
-                Frame::new(b"UNSUBSCRIBE", &[(b"id", Some(Borrowed(id.as_bytes())))], None),
-            
-            Send { ref destination, ref transaction, ref headers, ref body, } => 
-            {
-                let mut hdr: Vec<(&[u8],Option<Cow<[u8]>>)> = vec![
+            Unsubscribe { ref id } => Frame::new(
+                b"UNSUBSCRIBE",
+                &[(b"id", Some(Borrowed(id.as_bytes())))],
+                None,
+            ),
+
+            Send {
+                ref destination,
+                ref transaction,
+                ref headers,
+                ref body,
+            } => {
+                let mut hdr: Vec<(&[u8], Option<Cow<[u8]>>)> = vec![
                     (b"destination", Some(Borrowed(destination.as_bytes()))),
                     (b"id", sb(transaction)),
                 ];
-                for (key,val) in headers {
+                for (key, val) in headers {
                     hdr.push((key.as_bytes(), Some(Borrowed(val.as_bytes()))));
                 }
                 Frame::new(b"SEND", &hdr, body.as_ref().map(|v| v.as_ref()))
-            },
+            }
 
-            Ack { ref id, ref transaction } => 
-                Frame::new(b"ACK",
-                &[  
+            Ack {
+                ref id,
+                ref transaction,
+            } => Frame::new(
+                b"ACK",
+                &[
                     (b"id", Some(Borrowed(id.as_bytes()))),
                     (b"transaction", sb(transaction)),
                 ],
                 None,
             ),
 
-            Nack { ref id, ref transaction, } => 
-                Frame::new(b"NACK",
+            Nack {
+                ref id,
+                ref transaction,
+            } => Frame::new(
+                b"NACK",
                 &[
                     (b"id", Some(Borrowed(id.as_bytes()))),
                     (b"transaction", sb(transaction)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use frame::Frame;
 pub mod client;
 mod frame;
 
-pub(crate) type Result<T> = std::result::Result<T, failure::Error>;
+pub(crate) type Result<T> = std::result::Result<T, anyhow::Error>;
 
 /// A representation of a STOMP frame
 #[derive(Debug)]


### PR DESCRIPTION
* Switch from failure to anyhow
* Bump tokio-util
* Change connection return type, since the previous was very complex to work with.

Some clippy fixes, but it seems that the heartbeat parsing was wrong according to clippy:
error: `splitn` called with `1` split
   --> src/frame.rs:351:21
    |
351 |     let mut split = hb.splitn(1, ',');
    |                     ^^^^^^^^^^^^^^^^^
    |
    = note: `#[deny(clippy::suspicious_splitn)]` on by default
    = note: the resulting iterator will always return the entire string followed by `None`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_splitn


Without knowing the protocol, I chagnged this to splitn(2,',') to actually split into 2 parts. 
