### PR TITLE
Add support for connection and subscription headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ futures = "0.3"
 tokio = { version = "1", features = ["net"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 nom = "7"
+typed-builder = "0.18.0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time", "macros", "rt-multi-thread"] }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -81,6 +81,18 @@ impl<'a> Frame<'a> {
         }
         buffer.put_u8(b'\x00');
     }
+
+    pub fn add_extra_headers(&mut self, headers: &'a [(Vec<u8>, Vec<u8>)]) {
+        if !headers.is_empty() {
+            let existing_headers: Vec<&[u8]> = self.headers.iter().map(|(k, _v)| *k).collect();
+            headers
+                .iter()
+                .filter(|f| !existing_headers.contains(&f.0.as_ref()))
+                .for_each(|(k, v)| {
+                    self.headers.push((k.as_ref(), Cow::Borrowed(v.as_ref())));
+                });
+        }
+    }
 }
 
 // Nom definitions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,9 @@ pub enum AckMode {
 
 impl Message<ToServer> {
     fn to_frame(&self) -> Frame {
-        self.content.to_frame()
+        let mut frame = self.content.to_frame();
+        frame.add_extra_headers(&self.extra_headers);
+        frame
     }
     #[allow(dead_code)]
     fn from_frame(frame: Frame) -> Result<Message<ToServer>> {


### PR DESCRIPTION
This is a first draft at supporting connection and subscription headers, to be able to use the ActiveMq stomp extentions 
https://activemq.apache.org/stomp

Not sure about having both connect and connect_with_headers, but I didn't want to add them to the regular connect function since the headers are a corner case. Same with subscribe. 

Also the to_client_msg will always have empty headers, just like for the Send... not sure how correct this is.

So, please have a look and see what you think. 