### PR TITLE
upgrade to nom7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0"
 futures = "0.3"
 tokio = { version = "1", features = ["net"] }
 tokio-util = { version = "0.7", features = ["codec"] }
-nom = "4"
+nom = "7"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["time", "macros", "rt-multi-thread"] }

--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -14,7 +14,13 @@ use tokio_stomp_2::*;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let conn = client::connect("127.0.0.1:61613", None, None).await?;
+    let conn = client::connect(
+        "127.0.0.1:61613",
+        "/".to_string(),
+        "guest".to_string().into(),
+        "guest".to_string().into(),
+    )
+    .await?;
 
     tokio::time::sleep(Duration::from_millis(200)).await;
 

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -11,7 +11,13 @@ use tokio_stomp_2::*;
 // `docker run -p 61613:61613 rmohr/activemq:latest`
 
 async fn client(listens: &str, sends: &str, msg: &[u8]) -> Result<(), anyhow::Error> {
-    let mut conn = client::connect("127.0.0.1:61613", None, None).await?;
+    let mut conn = client::connect(
+        "127.0.0.1:61613",
+        "/".to_string(),
+        "guest".to_string().into(),
+        "guest".to_string().into(),
+    )
+    .await?;
     conn.send(client::subscribe(listens, "myid")).await?;
 
     loop {

--- a/examples/receive_message.rs
+++ b/examples/receive_message.rs
@@ -8,9 +8,14 @@ use tokio_stomp_2::FromServer;
 
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
-    let mut conn = client::connect("127.0.0.1:61613", None, None)
-        .await
-        .unwrap();
+    let mut conn = client::connect(
+        "127.0.0.1:61613",
+        "/".to_string(),
+        "guest".to_string().into(),
+        "guest".to_string().into(),
+    )
+    .await
+    .unwrap();
 
     conn.send(client::subscribe("queue.test", "custom-subscriber-id"))
         .await

--- a/examples/send_message.rs
+++ b/examples/send_message.rs
@@ -8,9 +8,14 @@ use tokio_stomp_2::ToServer;
 
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
-    let mut conn = client::connect("127.0.0.1:61613", None, None)
-        .await
-        .unwrap();
+    let mut conn = client::connect(
+        "127.0.0.1:61613",
+        "/".to_string(),
+        "guest".to_string().into(),
+        "guest".to_string().into(),
+    )
+    .await
+    .unwrap();
 
     conn.send(
         ToServer::Send {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,3 @@
-use std::net::ToSocketAddrs;
-
 use bytes::{Buf, BytesMut};
 use futures::prelude::*;
 use futures::sink::SinkExt;
@@ -17,15 +15,14 @@ use anyhow::{anyhow, bail};
 /// If successful, returns a tuple of a message stream and a sender,
 /// which may be used to receive and send messages respectively.
 pub async fn connect(
-    address: impl Into<String>,
+    server: impl tokio::net::ToSocketAddrs,
+    host: impl Into<String>,
     login: Option<String>,
     passcode: Option<String>,
 ) -> Result<ClientTransport> {
-    let address = address.into();
-    let addr = address.as_str().to_socket_addrs().unwrap().next().unwrap();
-    let tcp = TcpStream::connect(&addr).await?;
+    let tcp = TcpStream::connect(server).await?;
     let mut transport = ClientCodec.framed(tcp);
-    client_handshake(&mut transport, address, login, passcode).await?;
+    client_handshake(&mut transport, host.into(), login, passcode).await?;
     Ok(transport)
 }
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -13,15 +13,15 @@ use nom::{
 use std::borrow::Cow;
 
 use crate::{AckMode, FromServer, Message, Result, ToServer};
-
 type HeaderTuple<'a> = (&'a [u8], Option<Cow<'a, [u8]>>);
+type Header<'a> = (&'a [u8], Cow<'a, [u8]>);
 
 #[derive(Debug)]
 pub(crate) struct Frame<'a> {
     command: &'a [u8],
     // TODO use ArrayVec to keep headers on the stack
     // (makes this object zero-allocation)
-    headers: Vec<(&'a [u8], Cow<'a, [u8]>)>,
+    headers: Vec<Header<'a>>,
     body: Option<&'a [u8]>,
 }
 
@@ -132,7 +132,7 @@ pub(crate) fn parse_frame(input: &[u8]) -> IResult<&[u8], Frame> {
     ))
 }
 
-fn parse_header(input: &[u8]) -> IResult<&[u8], (&[u8], Cow<[u8]>)> {
+fn parse_header(input: &[u8]) -> IResult<&[u8], Header> {
     complete(separated_pair(
         is_not(":\r\n"),
         tag(":"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
 //! tokio-stomp - A library for asynchronous streaming of STOMP messages
 
-#[macro_use]
-extern crate nom;
-
 use custom_debug_derive::CustomDebug;
 use frame::Frame;
 


### PR DESCRIPTION
- upgrade to nom7
- distinguish between `host` and `server address`.
---
In the STOMP protocol specification, "host" and "server-address" are different concepts.

> host : The name of a virtual host that the client wishes to connect to. It is recommended clients set this to the host name that the socket was established against, or to any name of their choosing. If this header does not match a known virtual host, servers supporting virtual hosting MAY select a default virtual host or reject the connection.

