### PR TITLE
feat: allow empty header values for compatibility with STOMP 1.1 and 1.2

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -136,7 +136,10 @@ fn parse_header(input: &[u8]) -> IResult<&[u8], Header> {
     complete(separated_pair(
         is_not(":\r\n"),
         tag(":"),
-        terminated(not_line_ending, line_ending).map(Cow::Borrowed),
+        terminated(
+            Parser::or(not_line_ending, tag("")), 
+            line_ending
+        ).map(Cow::Borrowed),
     ))
     .parse(input)
 }


### PR DESCRIPTION
In STOMP 1.1 and 1.2, header values are defined as:

> `header-value        = *<any OCTET except CR or LF or ":">`

Where previously they were defined as:

> `header-value        = 1*<any CHAR except LF>`

Due to a quirk of the `not_line_ending` and `terminated` combinators, the parser was failing on empty header values, of the form `correlation-id:\n`, due to the `not_line_ending` combinator not having enough input.

This solution adds a single fallback tag to the terminated call, allowing it to gracefully parse empty values as "".